### PR TITLE
Set custom vocabulary in TranscribeVideo operator

### DIFF
--- a/src/views/UploadToAWSS3.vue
+++ b/src/views/UploadToAWSS3.vue
@@ -769,7 +769,8 @@ export default {
             workflow_config.Configuration.TranslateStage2.TranslateWebCaptions.ParallelDataNames = this.parallelData
           }
           if (this.customVocab !== null) {
-            workflow_config.Configuration.defaultAudioStage2.Transcribe.VocabularyName = this.customVocab
+            //workflow_config.Configuration.defaultAudioStage2.Transcribe.VocabularyName = this.customVocab
+            workflow_config.Configuration.defaultAudioStage2.TranscribeVideo.VocabularyName = this.customVocab
           }
           if (this.existingSubtitlesFilename == "") {
             if ("ExistingSubtitlesObject" in workflow_config.Configuration.WebCaptionsStage2.WebCaptions){


### PR DESCRIPTION
*Issue #, if available:*
#101
*Description of changes:*
Set the custom vocabulary on the TranscribeVideo operator.  We changed operators from Transcribe to TranscribVIdeo for this workflow, but we are still setting the vocabulary on Transcribe.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
