### PR TITLE
Add form for enabling Comprehend encryption

### DIFF
--- a/source/website/src/views/UploadToAWSS3.vue
+++ b/source/website/src/views/UploadToAWSS3.vue
@@ -136,10 +136,30 @@
                 <b-form-checkbox-group
                   id="checkbox-group-3"
                   v-model="enabledOperators"
-                  :options="textOperators"
-                  name="flavour-3"
-                ></b-form-checkbox-group>
-                <div v-if="enabledOperators.includes('Translate')">
+                  name="textOperators"
+                >
+                  <b-form-checkbox value="ComprehendEntities">
+                    Comprehend Entities
+                  </b-form-checkbox>
+                  <b-form-checkbox value="ComprehendKeyPhrases">
+                    Comprehend Key Phrases
+                  </b-form-checkbox>
+                    <b-form-checkbox
+                    v-if="enabledOperators.includes('ComprehendEntities') || enabledOperators.includes('ComprehendKeyPhrases')"
+                    v-model="ComprehendEncryption"
+                  >
+                    Encrypt Comprehend Job
+                  </b-form-checkbox>
+                  <b-form-input
+                    v-if="ComprehendEncryption && (enabledOperators.includes('ComprehendEntities') || enabledOperators.includes('ComprehendKeyPhrases'))"
+                    v-model="kmsKeyId"
+                    placeholder="Enter KMS key ID"
+                  ></b-form-input>
+                  <b-form-checkbox value="Translate">
+                    Translate
+                  </b-form-checkbox>
+
+                  <div v-if="enabledOperators.includes('Translate')">
                    <!-- && customTerminologyList.length > 0"> -->
                    <!-- && customTerminologyList.filter(x => x.SourceLanguageCode === sourceLanguageCode).length > 0"> -->
                   <div v-if="customTerminology.length > 0"><b>Custom Terminologies:</b> ({{ customTerminology.length }} selected)</div>
@@ -175,6 +195,7 @@
                     </ul>
                   </div>
                 </div>
+              </b-form-checkbox-group>
                 <div v-if="enabledOperators.includes('Translate')" >
                   <b-form-group>
                     <b>Target Languages:</b>

--- a/test/e2e/test_app.py
+++ b/test/e2e/test_app.py
@@ -78,7 +78,6 @@ def test_complete_app(browser, workflow_with_customizations, testing_env_variabl
     time.sleep(5)
     # Configure transcribe
     transcribe_language_box = browser.find_element_by_xpath("/html/body/div/div/div[2]/div[2]/div/div[1]/div[2]/div[2]/fieldset/div/div/div[2]/select[1]")
-    
     # # default language is en-US
     assert transcribe_language_box.get_attribute("value") == "en-US"
     
@@ -94,17 +93,17 @@ def test_complete_app(browser, workflow_with_customizations, testing_env_variabl
 
     # Configure translate language to en-ES
     
-    translate_languages_box = browser.find_element_by_xpath("/html/body/div/div/div[2]/div[2]/div/div[1]/div[3]/div[2]/fieldset/div/div[3]/fieldset/div/div[2]/div[1]/p/input")
+    translate_languages_box = browser.find_element_by_xpath("/html/body/div/div/div[2]/div[2]/div/div[1]/div[3]/div[2]/fieldset/div/div[2]/fieldset/div/div[2]/div[1]/p/input")
     assert translate_languages_box.get_attribute("textContent") == ""
     # Select spanish badge
-    browser.find_element_by_xpath("/html/body/div/div/div[2]/div[2]/div/div[1]/div[3]/div[2]/fieldset/div/div[3]/fieldset/div/div/div[2]/p/span[44]").click() 
+    browser.find_element_by_xpath("/html/body/div/div/div[2]/div[2]/div/div[1]/div[3]/div[2]/fieldset/div/div[2]/fieldset/div/div/div[2]/p/span[44]").click() 
 
     # Check that spanish badge is in the input box
-    assert browser.find_element_by_xpath("/html/body/div/div/div[2]/div[2]/div/div[1]/div[3]/div[2]/fieldset/div/div[3]/fieldset/div/div/div[1]/span/span").get_attribute("textContent") == "Spanish"
+    assert browser.find_element_by_xpath("/html/body/div/div/div[2]/div[2]/div/div[1]/div[3]/div[2]/fieldset/div/div[2]/fieldset/div/div/div[1]/span/span").get_attribute("textContent") == "Spanish"
 
     # click the Swedish badge
-    browser.find_element_by_xpath("/html/body/div/div/div[2]/div[2]/div/div[1]/div[3]/div[2]/fieldset/div/div[3]/fieldset/div/div/div[2]/p/span[45]").click()
-    assert browser.find_element_by_xpath("/html/body/div/div/div[2]/div[2]/div/div[1]/div[3]/div[2]/fieldset/div/div[3]/fieldset/div/div/div[1]/span[2]/span").get_attribute("textContent") == "Swedish"
+    browser.find_element_by_xpath("/html/body/div/div/div[2]/div[2]/div/div[1]/div[3]/div[2]/fieldset/div/div[2]/fieldset/div/div/div[2]/p/span[45]").click()
+    assert browser.find_element_by_xpath("/html/body/div/div/div[2]/div[2]/div/div[1]/div[3]/div[2]/fieldset/div/div[2]/fieldset/div/div/div[1]/span[2]/span").get_attribute("textContent") == "Swedish"
     
      ####### Collection View
      # Navigate to Collection view


### PR DESCRIPTION
*Issue #, if available:*
Add form for enabling encryption for Comprehend

*Description of changes:*

The HTML form elements were missing for enabling encryption for Comprehend.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
